### PR TITLE
bobtemplates.plone, PrintingMailHost and plone.api

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -26,7 +26,7 @@ buildout_dir = ${buildout:directory}
 
 # Extend the coredevs-checkouts with our own
 auto-checkout +=
-    bobtemplates.plone
+#    bobtemplates.plone
     ploneconf.site_sneak
 #    starzel.votable_behavior
 #   ploneconf.site
@@ -51,6 +51,7 @@ eggs =
     plone.reload
     Products.PDBDebugMode
     plone.app.debugtoolbar
+    Products.PrintingMailHost
 
 # TTW Forms (based on Archetypes)
     Products.PloneFormGen
@@ -130,7 +131,7 @@ ploneconf.site = fs ploneconf.site path=src
 starzel.votable_behavior = git https://github.com/collective/starzel.votable_behavior.git pushurl=git://github.com/collective/starzel.votable_behavior.git path=src
 
 # We use the unreleased version of bobtemplates.plone since it asks less questions
-bobtemplates.plone = git https://github.com/plone/bobtemplates.plone.git rev=b09362f314b4fd6cce22691898e1d79e9cf2f27f
+#bobtemplates.plone = git https://github.com/plone/bobtemplates.plone.git rev=b09362f314b4fd6cce22691898e1d79e9cf2f27f
 
 # This is no egg but folders each containing the egg of ploneconf.site for one chapter
 ploneconf.site_sneak = git https://github.com/collective/ploneconf.site_sneak.git path=src egg=false branch=plone5

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,17 +2,18 @@
 # dev tools
 Products.PDBDebugMode = 1.3.1
 corneti.recipes.codeintel = 0.3
-plone.api = 1.3.2
+plone.api = 1.4.6
 plone.app.debugtoolbar = 1.0
 z3c.jbot = 0.7.2
+Products.PrintingMailHost = 0.8
 
-# pinns for some Addons
+# pins for some Addons
 Products.PloneFormGen = 1.8.0.alpha1
 Products.PythonField = 1.1.3
 Products.TALESField = 1.1.3
 Products.TemplateFields = 1.2.5
 
-# pinns for mr.bob and bobtemplates.plone
+# pins for mr.bob and bobtemplates.plone
 MarkupSafe = 0.23
 bobtemplates.plone = 0.8
 mr.bob = 0.1.1
@@ -22,7 +23,7 @@ ply = 3.4
 setuptools = 12.2
 zc.buildout = 2.3.1
 
-# Some other pinns from coredev
+# Some other pins from coredev
 Products.PloneTestCase = 0.9.18
 PyYAML = 3.11
 argh = 0.26.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -8,20 +8,20 @@ z3c.jbot = 0.7.2
 Products.PrintingMailHost = 0.8
 
 # pins for some Addons
-Products.PloneFormGen = 1.8.0.alpha1
+Products.PloneFormGen = 1.8.0b4
 Products.PythonField = 1.1.3
 Products.TALESField = 1.1.3
 Products.TemplateFields = 1.2.5
 
 # pins for mr.bob and bobtemplates.plone
 MarkupSafe = 0.23
-bobtemplates.plone = 0.8
-mr.bob = 0.1.1
+bobtemplates.plone = 0.11
+mr.bob = 0.1.2
 ply = 3.4
 
 # buildout
-setuptools = 12.2
-zc.buildout = 2.3.1
+setuptools = 18.3.1
+zc.buildout = 2.4.3
 
 # Some other pins from coredev
 Products.PloneTestCase = 0.9.18


### PR DESCRIPTION
The released bobtemplates.plone is probably ok now.
Add Products.PrintingMailHost, very useful.
Products.CMFPlone now pins plone.api >= 1.4.4.