### PR TITLE
Vagrant xenial update: vagrant -> ubuntu

### DIFF
--- a/vagrant.cfg
+++ b/vagrant.cfg
@@ -9,4 +9,4 @@ extends =
 #
 # This is all set to non-shared folder because a shared folder should
 # hold neither symlinks nor large/many files
-buildout_dir = /home/vagrant
+buildout_dir = /home/ubuntu


### PR DESCRIPTION
This is needed to make the training buildout work with the `ubuntu/xenial64` base box.