### PR TITLE
Don't merge yet: Default user name has changed from ubuntu to vagrant in the ubuntu/bionic64 Vagrant image

### DIFF
--- a/vagrant.cfg
+++ b/vagrant.cfg
@@ -9,4 +9,4 @@ extends =
 #
 # This is all set to non-shared folder because a shared folder should
 # hold neither symlinks nor large/many files
-buildout_dir = /home/ubuntu
+buildout_dir = /home/vagrant


### PR DESCRIPTION
These changes will not work with the `xenial`  image, i.e. you will currently need the `vagrant_bionic` branch of the training when using this branch (s. https://github.com/plone/training/pull/339).

This PR should only be merged once https://github.com/plone/training/pull/339 is merged. https://github.com/plone/training/blob/c3f88161b76bfd488156ba54dc453b9d458fd036/plone_training_config/manifests/plone.pp#L85 can then be changed back to master. Until then this branch is needed and should not be deleted.