### PR TITLE
Upgraded Plone and requirements

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://dist.plone.org/release/5.1.2/versions.cfg
+    http://dist.plone.org/release/5.1.4/versions.cfg
     versions.cfg
 extends-cache = extends-cache
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools == 33.1.1
-zc.buildout == 2.9.5
+setuptools == 39.1.0
+zc.buildout == 2.11.4

--- a/versions.cfg
+++ b/versions.cfg
@@ -9,8 +9,7 @@ colorama = 0.3.9
 wmctrl = 0.3
 
 # pins for Addons
-collective.easyform = 2.0.0b5
-plone.api = 1.8.4
+collective.easyform = 2.0.0
 
 # pins for mr.bob and bobtemplates.plone
 MarkupSafe = 1.0


### PR DESCRIPTION
A couple upgrades for the upcoming Ploneconf Trainings in Tokyo:

- Plone 5.1.4
- setuptools 39.1.0
- zc.buildout 2.11.4

setuptools and zc.buildout might not be the latest already, but are the newest that I've tried and are working properly, feel free to provide feedback if you tried some newer versions.