### PR TITLE
Update Makefile to fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help: ## This help message
 
 bin/pip:
 	@echo "$(GREEN)==> Setup Virtual Env$(RESET)"
-	python -m venv venv
+	python3 -m venv venv
 	venv/bin/pip install -U "pip" "wheel" "cookiecutter" "mxdev"
 
 instance/etc/zope.ini:	bin/pip


### PR DESCRIPTION
I see that this was fixed [before](https://github.com/plone/training/issues/732#issuecomment-1459929155) but reverted again [here](https://github.com/collective/training_buildout/commit/4758c38a18c50e2b38dd783813e375a2f38d7e49)
Submitting this just in case the second change was unintentional.

Chapter 5. in Mastering Plone 6 development `make build` [command](https://training.plone.org/mastering-plone/installation.html#id1 ) produces a build error. Modifying the Makefile by changing python to python3 fixes the issue.